### PR TITLE
A monir typo fix

### DIFF
--- a/julia/src/spherical.jl
+++ b/julia/src/spherical.jl
@@ -46,7 +46,7 @@ struct SphericalHarmonics{L, NORM, STATIC, T1}
 end
 
 SphericalHarmonics(L::Integer; kwargs...) = 
-      SphericalHarmonics(SolidHarmonics(L, kwargs...), 
+      SphericalHarmonics(SolidHarmonics(L; kwargs...), 
                          ArrayPool(FlexArrayCache))
 
 


### PR DESCRIPTION
`SolidHarmonics` is now called as `SolidHarmonics(maxL; ...)` but in `SphericalHarmonics` it is called using `,` (a typo), which leads to the following error:

```julia
SphericalHarmonics(5; normalisation = :L2)
ERROR: MethodError: no method matching SpheriCart.SolidHarmonics(::Int64, ::Pair{Symbol, Symbol})

Closest candidates are:
  SpheriCart.SolidHarmonics(::Integer; normalisation, static, T)
   @ SpheriCart ~/.julia/packages/SpheriCart/yUX6s/src/api.jl:42
```

This PR just fixes this typo.